### PR TITLE
Apply background model refresh to the picker; correct thinking-level docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Optimized for deep reasoning, long-horizon coding & autonomous agentic workflows
 
 | Model ID | Creator / Lab | Context | Max Output | Thinking | Vision |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| `muse-spark-1.2-contributor-free` | Meta Superintelligence Labs | **1M** (1.048.576) | **131K** (131.072) | `minimal → max` | ✅ |
+| `muse-spark-1.2-contributor-free` | Meta Superintelligence Labs | **1M** (1.048.576) | **131K** (131.072) | `minimal / low / medium / high / xhigh / max` | ✅ |
 | `x-preview-f-free` | Ox Alpha | **1M** (1.048.576) | **131K** (131.072) | `low / high / max` | ✅ |
 | `mimo-v2.5-free` | Xiaomi MiMo | **1M** (1.048.576) | **131K** (131.072) | `low / medium / high` | ✅ |
-| `deepseek-v4-flash-free` | DeepSeek | **1M** (1.000.000) | **384K** (384.000) | `low → max` | ❌ |
-| `laguna-s-2.1-free` | Poolside | **1M** (1.048.576) | **131K** (131.072) | `low → max` | ❌ |
-| `nemotron-3.5-lightning-free` | NVIDIA | **1M** (1.000.000) | **262K** (262.144) | `low → max` | ❌ |
-| `nemotron-3-ultra-free` | NVIDIA | **1M** (1.000.000) | **128K** (128.000) | `low → max` | ❌ |
-| `hy3-free` | Tencent Hunyuan | **262K** (262.144) | **262K** (262.144) | `low → max` | ❌ |
+| `deepseek-v4-flash-free` | DeepSeek | **1M** (1.000.000) | **384K** (384.000) | `low / high / max` | ❌ |
+| `laguna-s-2.1-free` | Poolside | **1M** (1.048.576) | **131K** (131.072) | `low / high / max` | ❌ |
+| `nemotron-3.5-lightning-free` | NVIDIA | **1M** (1.000.000) | **262K** (262.144) | `low / high / max` | ❌ |
+| `nemotron-3-ultra-free` | NVIDIA | **1M** (1.000.000) | **128K** (128.000) | `low / high / max` | ❌ |
+| `hy3-free` | Tencent Hunyuan | **262K** (262.144) | **262K** (262.144) | `low / high / max` | ❌ |
 | `big-pickle` | Big Pickle | **200K** (200.000) | **32K** (32.000) | `high / max` | ❌ |
 
 #### KiloCode Gateway (14 Models), OpenRouter Compatible
@@ -58,20 +58,22 @@ Keyless access with `Bearer kilo-free`. Clean slash-free and colon-free CLI alia
 
 | Model ID | Creator / Lab | Context | Max Output | Thinking | Vision |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| `dots-3-note-preview` (`dots-studio/...:free`) | Dots Studio | **512K** (512.000) | **512K** (512.000) | `openrouter` (auto) | ✅ |
-| `step-3.7-flash` (`stepfun/...:free`) | StepFun | **262K** (262.144) | **262K** (262.144) | `openrouter` (auto) | ✅ |
-| `nemotron-3-nano-omni` (`nvidia/...:free`) | NVIDIA | **256K** (256.000) | **65K** (65.536) | `openrouter` (auto) | ✅ |
-| `nemotron-3-ultra-550b` (`nvidia/...:free`) | NVIDIA | **1M** (1.000.000) | **65K** (65.536) | `openrouter` (auto) | ❌ |
-| `nvidia/nemotron-3.5-lightning:free` | NVIDIA | **1M** (1.000.000) | **131K** (131.072) | `openrouter` (auto) | ❌ |
-| `nemotron-3-super` (`nvidia/...:free`) | NVIDIA | **262K** (262.144) | **262K** (262.144) | `openrouter` (auto) | ❌ |
-| `hy3:free` (`tencent/hy3:free`) | Tencent Hunyuan | **262K** (262.144) | **262K** (262.144) | `openrouter` (auto) | ❌ |
-| `north-mini-code` (`cohere/...:free`) | Cohere | **256K** (256.000) | **64K** (64.000) | `openrouter` (auto) | ❌ |
-| `laguna-s-2.1:free` (`poolside/...:free`) | Poolside | **1M** (1.048.576) | **131K** (131.072) | `openrouter` (auto) | ❌ |
-| `laguna-xs-2.1:free` (`poolside/...:free`) | Poolside | **262K** (262.144) | **32K** (32.768) | `openrouter` (auto) | ❌ |
-| `lfm-2.5` (`liquid/lfm-2.5-2.6b:free`) | Liquid AI | **128K** (128.000) | **32K** (32.768) | `openrouter` (auto) | ❌ |
+| `dots-3-note-preview` (`dots-studio/...:free`) | Dots Studio | **512K** (512.000) | **512K** (512.000) | `minimal…xhigh`\* | ✅ |
+| `step-3.7-flash` (`stepfun/...:free`) | StepFun | **262K** (262.144) | **262K** (262.144) | `minimal…xhigh`\* | ✅ |
+| `nemotron-3-nano-omni` (`nvidia/...:free`) | NVIDIA | **256K** (256.000) | **65K** (65.536) | `minimal…xhigh`\* | ✅ |
+| `nemotron-3-ultra-550b` (`nvidia/...:free`) | NVIDIA | **1M** (1.000.000) | **65K** (65.536) | `minimal…xhigh`\* | ❌ |
+| `nvidia/nemotron-3.5-lightning:free` | NVIDIA | **1M** (1.000.000) | **131K** (131.072) | `minimal…xhigh`\* | ❌ |
+| `nemotron-3-super` (`nvidia/...:free`) | NVIDIA | **262K** (262.144) | **262K** (262.144) | `minimal…xhigh`\* | ❌ |
+| `hy3:free` (`tencent/hy3:free`) | Tencent Hunyuan | **262K** (262.144) | **262K** (262.144) | ❌ *(none sent)* | ❌ |
+| `north-mini-code` (`cohere/...:free`) | Cohere | **256K** (256.000) | **64K** (64.000) | `minimal…xhigh`\* | ❌ |
+| `laguna-s-2.1:free` (`poolside/...:free`) | Poolside | **1M** (1.048.576) | **131K** (131.072) | `minimal…xhigh`\* | ❌ |
+| `laguna-xs-2.1:free` (`poolside/...:free`) | Poolside | **262K** (262.144) | **32K** (32.768) | `minimal…xhigh`\* | ❌ |
+| `lfm-2.5` (`liquid/lfm-2.5-2.6b:free`) | Liquid AI | **128K** (128.000) | **32K** (32.768) | `minimal…xhigh`\* | ❌ |
 | `kilo-auto` (`kilo-auto/free`) | Kilo Gateway Auto | **256K** (256.000) | **10K** (10.000) | ❌ *(non-thinking)* | ❌ |
 | `openrouter` (`openrouter/free`) | OpenRouter Free | **200K** (200.000) | **65K** (65.536) | ❌ *(non-thinking)* | ✅ |
 | `content-safety` (`nvidia/...:free`) | NVIDIA | **128K** (128.000) | **8K** (8.192) | ❌ *(non-thinking)* | ✅ |
+
+\* Levels are forwarded as-is through the OpenRouter-style nested `reasoning` parameter; effort mapping is decided by each model. hy3 accepts no reasoning parameter today.
 
 ---
 
@@ -233,7 +235,7 @@ Log rotation at 5MB. Clean, parseable, real-time HTTP lifecycle tracking.
 
 This package stays thin. It ships three things: a model catalog, a relay proxy, and a log. There is no build step and there are no runtime dependencies. Thinking and prompt normalization stay with the host (`pi-ai`).
 
-Current size: about 3.6k lines including tests. 53 tests pass, typecheck clean.
+Current size: about 4.6k lines including tests. 16 tests pass, typecheck clean.
 
 ---
 
@@ -273,7 +275,7 @@ cd pi-freeflow
 pnpm install
 
 # run all three before opening a PR
-pnpm test        # 53 tests across 12 test files
+pnpm test        # 16 tests across 2 test files
 pnpm typecheck   # tsc --noEmit, must pass clean
 pnpm smoke       # verifies extensions/index.ts loads without crashing
 ```

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -54,6 +54,21 @@ export function setAliveCatalog(catalog: RegisteredModel[]): void {
 }
 
 /**
+ * Overlay a refreshed model list onto a base list without dropping base entries.
+ * Fresh entries win on id collision; unknown fresh ids are appended after the base.
+ * Guards the background refresh against a partial upstream cache removing
+ * verified static models from provider registration.
+ */
+export function mergeCatalog(
+	base: RegisteredModel[],
+	fresh: RegisteredModel[],
+): RegisteredModel[] {
+	const byId = new Map(base.map((m) => [m.id, m]));
+	for (const m of fresh) byId.set(m.id, m);
+	return [...byId.values()];
+}
+
+/**
  * Format a clean, human-readable display name for any upstream model ID.
  */
 export function formatCleanDisplayName(id: string, customName?: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 import type * as http from "node:http";
 import {
 	getAliveCatalog,
+	mergeCatalog,
 	readCatalogCache,
 	refreshCatalog,
 	setAliveCatalog,
@@ -157,7 +158,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 				setAliveCatalog(aliveModels);
 				pi.registerProvider(
 					"freeflow",
-					buildProviderConfig(registeredCatalog, actualPort),
+					buildProviderConfig(mergeCatalog(registeredCatalog, aliveModels), actualPort),
 				);
 				logInfo(
 					`Catalog refreshed: ${aliveModels.length} models verified active`,

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,8 +2,8 @@
  * Static model definitions and upstream routing catalogs for pi-freeflow
  *
  * Defines the 23 verified free models:
- * - 9 OpenCode Zen models (2 Responses API + 7 Chat Completions)
- * - 14 KiloCode Keyless Gateway models (11 OpenRouter format + 3 Standard format)
+ * - 9 OpenCode Zen models (1 Responses API + 8 Chat Completions)
+ * - 14 KiloCode Keyless Gateway models (10 OpenRouter format + 4 Standard format)
  */
 
 import type { ModelDef, Upstream } from "./types.ts";

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for catalog merging.
+ *
+ * The background catalog refresh must never remove verified static models from
+ * provider registration, even when a cached upstream list is partial, and fresh
+ * entries must override stale ones by id.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mergeCatalog } from "../src/catalog.ts";
+import type { RegisteredModel } from "../src/types.ts";
+
+function model(id: string, maxTokens: number, source: "opencode" | "kilo"): RegisteredModel {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		contextWindow: 1000,
+		maxTokens,
+		input: ["text"],
+		source,
+	};
+}
+
+const BASE: RegisteredModel[] = [model("alpha-free", 100, "opencode"), model("beta-free", 200, "kilo")];
+
+test("mergeCatalog overrides matching ids with fresh entries", () => {
+	const merged = mergeCatalog(BASE, [model("alpha-free", 999, "opencode")]);
+	assert.equal(merged.length, 2);
+	const alpha = merged.find((m) => m.id === "alpha-free");
+	assert.ok(alpha);
+	assert.equal(alpha.maxTokens, 999);
+});
+
+test("mergeCatalog keeps base entries missing from the fresh list", () => {
+	const merged = mergeCatalog(BASE, [model("alpha-free", 111, "opencode")]);
+	assert.ok(merged.some((m) => m.id === "beta-free"));
+	assert.equal(merged.find((m) => m.id === "beta-free")?.maxTokens, 200);
+});
+
+test("mergeCatalog appends unknown fresh ids after the base", () => {
+	const merged = mergeCatalog(BASE, [model("gamma-new", 300, "kilo")]);
+	assert.deepEqual(
+		merged.map((m) => m.id),
+		["alpha-free", "beta-free", "gamma-new"],
+	);
+});
+
+test("mergeCatalog with an empty fresh list returns the base unchanged", () => {
+	const merged = mergeCatalog(BASE, []);
+	assert.deepEqual(merged, BASE);
+});


### PR DESCRIPTION
## Fixed

- **Refreshed and newly discovered free models now appear in the model picker without a restart.**
  - What changed: the periodic background catalog check now updates the registered model list. Previously its results only reached internal listings; the picker kept the startup list until a manual management command was run.
  - Who is affected: everyone, on every session start.
  - Action needed: none.
- **A partial cached model list can no longer remove known models from the picker.** Refreshed data is overlaid onto the verified startup set instead of replacing it.

## Docs

- Model tables now show the exact selectable thinking levels per model and how each gateway family transmits them (OpenRouter-style nested `reasoning` object vs standard `reasoning_effort`), including the one gateway model that currently accepts no reasoning parameter.
- Test and size statistics updated to match the current suite (16 tests, about 4.6k lines including tests).

## Verification

- `pnpm test` — 16 pass, 0 fail
- `pnpm typecheck` — clean
- `pnpm smoke` — extension loads
